### PR TITLE
Add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,17 @@ will be rendered as:
 ```java
 doTheThingThatWeActuallyWantToShow();
 ```
+
+## Building the Project
+
+Install the dependencies:
+
+```shell
+pip install -r requirements.txt
+pip install nose # Optionally, install nose to run the tests
+```
+
+Run the tests:
+```shell
+nosetests
+```

--- a/README.md
+++ b/README.md
@@ -3,6 +3,23 @@
 A plugin for mkdocs that allows some advanced 'includes' functionality to be used for embedded code blocks.
 This is effectively an extended Markdown format, but is intended to degrade gracefully when rendered with a different renderer. 
 
+## Installation
+
+1. Add dependency on the plugin:
+
+```requirements.txt
+-e git+https://github.com/rnorth/mkdocs-codeinclude-plugin#egg=mkdocs_codeinclude_plugin
+```
+
+You have to use Git dependency specification until the plugin is published on PyPy.
+
+2. Add `codeinclude` to the list of your MkDocs plugins (typically listed in `mkdocs.yml`):
+
+```yaml
+plugins:
+  - codeinclude
+```
+
 ## Usage
 
 A codeinclude block resembles a regular markdown link surrounded by a pair of XML comments, e.g.:

--- a/README.md
+++ b/README.md
@@ -3,4 +3,79 @@
 A plugin for mkdocs that allows some advanced 'includes' functionality to be used for embedded code blocks.
 This is effectively an extended Markdown format, but is intended to degrade gracefully when rendered with a different renderer. 
 
-This README will be extended to include examples at a later date.
+## Usage
+
+A codeinclude block will resemble a regular markdown link surrounded by a pair of XML comments, e.g.:
+
+<!-- 
+To prevent this from being rendered as a codeinclude when rendering this page, we use HTML tags.
+See this in its rendered form to understand its actual appearance, or look at other pages in the
+docs.
+-->
+
+<pre><code>&lt;!--codeinclude--&gt;
+[Human readable title for snippet](./relative_path_to_example_code.java) targeting_expression
+&lt;!--/codeinclude--&gt;
+</code></pre>
+
+Where `targeting_expression` could be:
+
+* `block:someString` or
+* `inside_block:someString`
+
+If these are provided, the macro will seek out any line containing the token `someString` and grab the next curly brace
+delimited block that it finds. `block` will grab the starting line and closing brace, whereas `inside_block` will omit 
+these.
+
+e.g., given:
+```java
+
+public class FooService {
+
+    public void doFoo() {
+        foo.doSomething();
+    }
+    
+    ...
+
+```
+
+If we use `block:doFoo` as our targeting expression, we will have the following content included into our page:
+
+```java
+public void doFoo() {
+    foo.doSomething();
+}
+```
+
+Whereas using `inside_block:doFoo` we would just have the inner content of the method included:
+
+```java
+foo.doSomething();
+```
+
+Note that:
+
+* Any code included will be have its indentation reduced
+* Every line in the source file will be searched for an instance of the token (e.g. `doFoo`). If more than one line
+  includes that token, then potentially more than one block could be targeted for inclusion. It is advisable to use a
+  specific, unique token to avoid unexpected behaviour.
+  
+When we wish to include a section of code that does not naturally appear within braces, we can simply insert our token,
+with matching braces, in a comment. 
+While a little ugly, this has the benefit of working in any context and is easy to understand. 
+For example:
+
+```java
+public class FooService {
+
+    public void boringMethod() {
+        doSomethingBoring();
+        
+        // doFoo {
+        doTheThingThatWeActuallyWantToShow();
+        // }
+    }
+
+
+``` 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is effectively an extended Markdown format, but is intended to degrade grac
 
 ## Usage
 
-A codeinclude block will resemble a regular markdown link surrounded by a pair of XML comments, e.g.:
+A codeinclude block resembles a regular markdown link surrounded by a pair of XML comments, e.g.:
 
 <!-- 
 To prevent this from being rendered as a codeinclude when rendering this page, we use HTML tags.
@@ -35,8 +35,6 @@ public class FooService {
     public void doFoo() {
         foo.doSomething();
     }
-    
-    ...
 
 ```
 
@@ -63,7 +61,8 @@ Note that:
   
 When we wish to include a section of code that does not naturally appear within braces, we can simply insert our token,
 with matching braces, in a comment. 
-While a little ugly, this has the benefit of working in any context and is easy to understand. 
+While a little ugly, this has the benefit of working in any context, even in languages that do not use
+curly braces, and is easy to understand. 
 For example:
 
 ```java
@@ -77,5 +76,10 @@ public class FooService {
         // }
     }
 
+```
 
-``` 
+will be rendered as:
+
+```java
+doTheThingThatWeActuallyWantToShow();
+```

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ public class FooService {
         foo.doSomething();
     }
 
+}
 ```
 
 If we use `block:doFoo` as our targeting expression, we will have the following content included into our page:
@@ -76,6 +77,7 @@ public class FooService {
         // }
     }
 
+}
 ```
 
 will be rendered as:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Where `targeting_expression` could be:
 
 If these are provided, the macro will seek out any line containing the token `someString` and grab the next curly brace
 delimited block that it finds. `block` will grab the starting line and closing brace, whereas `inside_block` will omit 
-these.
+these. If no `targeting_expression` is provided, the whole file is included.
 
 e.g., given:
 ```java


### PR DESCRIPTION
The documentation is mainly imported from testcontainers project as-is, hence might be easier to review commit-by-commit.

See https://github.com/testcontainers/testcontainers-java/blob/master/docs/contributing_docs.md#codeincludes
and
https://github.com/testcontainers/testcontainers-java/blob/master/LICENSE