### PR TITLE
Always use UTF-8:

### DIFF
--- a/codeinclude/plugin.py
+++ b/codeinclude/plugin.py
@@ -36,7 +36,8 @@ def get_substitute(page, title, filename, lines, block, inside_block):
 
     page_parent_dir = os.path.dirname(page.file.abs_src_path)
     import_path = os.path.join(page_parent_dir, filename)
-    with open(import_path) as f:
+    # Always use UTF-8, as it is the recommended default for source file encodings.
+    with open(import_path, encoding='UTF-8') as f:
         content = f.read()
 
     selected_content = select(

--- a/tests/codeinclude/fixture/Bar.java
+++ b/tests/codeinclude/fixture/Bar.java
@@ -1,3 +1,3 @@
 public class Bar {
-
+  // This UTF-8 encoded file has some multi-byte characters: œ, ë
 }

--- a/tests/codeinclude/test_plugin.py
+++ b/tests/codeinclude/test_plugin.py
@@ -78,7 +78,7 @@ class PluginTextCase(unittest.TestCase):
 
                                   ```java tab=\"bar\"
                                   public class Bar {
-
+                                    // This UTF-8 encoded file has some multi-byte characters: œ, ë
                                   }
                                   ```
 


### PR DESCRIPTION
Always use UTF-8 as it is commonly used
for platform-independent source files.

Fixes issues on Windows with multi-byte characters.