### PR TITLE
Allow selectors on next line

### DIFF
--- a/codeinclude/plugin.py
+++ b/codeinclude/plugin.py
@@ -133,13 +133,15 @@ def substitute(markdown: str, substitutes: List[Replacement]) -> str:
     # Perform substitutions
     result = ""
     index = 0
-    markdown_lines = markdown.splitlines()
-    while index < len(markdown_lines):
+    lines = markdown.splitlines()
+    while index < len(lines):
         if index in substitutes_by_first_line.keys():
+            # Replace the codeinclude fragment starting at this line
             substitute = substitutes_by_first_line[index]
             result += substitute.content
             index = substitute.last_line_index
         else:
-            result += markdown_lines[index] + "\n"
+            # Keep the input line
+            result += lines[index] + "\n"
         index += 1
     return result

--- a/codeinclude/plugin.py
+++ b/codeinclude/plugin.py
@@ -3,7 +3,7 @@ import os
 import shlex
 import textwrap
 from dataclasses import dataclass
-from typing import List
+from typing import Dict
 
 from mkdocs.plugins import BasePlugin
 from codeinclude.resolver import select
@@ -57,22 +57,19 @@ class CodeIncludeBlock(object):
     content: str
 
 
-def find_code_include_blocks(markdown: str) -> List[CodeIncludeBlock]:
-    ci_blocks = list()
-    index = 0
+def find_code_include_blocks(markdown: str) -> Dict[int, CodeIncludeBlock]:
+    ci_blocks = dict()
+    first = -1
     lines = markdown.splitlines()
-    while index < len(lines):
+    for index, line in enumerate(lines):
         if re.match(RE_START, lines[index]):
-            # Start of the ci block
-            start = index
-            index += 1
-            # Find the end of the ci block
-            while index < len(lines) and not re.match(RE_END, lines[index]):
-                index += 1
-            if index < len(lines):
-                last = index
-                content = '\n'.join(lines[start:last+1])
-                ci_blocks.append(CodeIncludeBlock(start, last, content))
+            first = index
+            continue
+        if re.match(RE_END, lines[index]):
+            last = index
+            content = '\n'.join(lines[first:last + 1])
+            ci_blocks[first] = CodeIncludeBlock(first, last, content)
+            first = -1
     return ci_blocks
 
 

--- a/tests/codeinclude/test_plugin.py
+++ b/tests/codeinclude/test_plugin.py
@@ -8,6 +8,13 @@ from mkdocs.structure.pages import Page
 
 from codeinclude.plugin import CodeIncludePlugin
 
+MARKDOWN_EXAMPLE_NO_INCLUDES = """
+# hello world
+
+some text before
+
+"""
+
 MARKDOWN_EXAMPLE_NO_SELECTOR = """
 # hello world
 
@@ -61,6 +68,13 @@ PAGE_EXAMPLE = Page("", File(os.path.abspath("./fixture/text.md"), "/src", "/des
 
 
 class PluginTextCase(unittest.TestCase):
+
+    def test_no_includes(self):
+        plugin = CodeIncludePlugin()
+        result = plugin.on_page_markdown(MARKDOWN_EXAMPLE_NO_INCLUDES, PAGE_EXAMPLE, dict())
+
+        self.assertEqual(MARKDOWN_EXAMPLE_NO_INCLUDES.strip(),
+                         result.strip())
 
     def test_simple_case_no_selector(self):
         plugin = CodeIncludePlugin()

--- a/tests/codeinclude/test_plugin.py
+++ b/tests/codeinclude/test_plugin.py
@@ -8,12 +8,35 @@ from mkdocs.structure.pages import Page
 
 from codeinclude.plugin import CodeIncludePlugin
 
-MARKDOWN_EXAMPLE = """
+MARKDOWN_EXAMPLE_NO_SELECTOR = """
 # hello world
 
 some text before
 <!--codeinclude-->
 [foo](Foo.java)
+<!--/codeinclude-->
+and some text after
+
+"""
+
+MARKDOWN_EXAMPLE_SELECTOR_ON_SAME_LINE = """
+# hello world
+
+some text before
+<!--codeinclude-->
+[foo](Foo.java) lines:1
+<!--/codeinclude-->
+and some text after
+
+"""
+
+MARKDOWN_EXAMPLE_SELECTOR_ON_NEXT_LINE = """
+# hello world
+
+some text before
+<!--codeinclude-->
+[foo](Foo.java)
+lines:1
 <!--/codeinclude-->
 and some text after
 
@@ -39,9 +62,9 @@ PAGE_EXAMPLE = Page("", File(os.path.abspath("./fixture/text.md"), "/src", "/des
 
 class PluginTextCase(unittest.TestCase):
 
-    def test_simple_case(self):
+    def test_simple_case_no_selector(self):
         plugin = CodeIncludePlugin()
-        result = plugin.on_page_markdown(MARKDOWN_EXAMPLE, PAGE_EXAMPLE, dict())
+        result = plugin.on_page_markdown(MARKDOWN_EXAMPLE_NO_SELECTOR, PAGE_EXAMPLE, dict())
 
         print(result)
         self.assertEqual(textwrap.dedent("""
@@ -55,6 +78,44 @@ class PluginTextCase(unittest.TestCase):
                                   }
                                   ```
                                   
+                                  and some text after
+                                  """).strip(),
+                         result.strip())
+
+    def test_simple_case_selector_on_same_line(self):
+        plugin = CodeIncludePlugin()
+        result = plugin.on_page_markdown(MARKDOWN_EXAMPLE_SELECTOR_ON_SAME_LINE, PAGE_EXAMPLE, dict())
+
+        print(result)
+        self.assertEqual(textwrap.dedent("""
+                                  # hello world
+
+                                  some text before
+
+                                  ```java tab=\"foo\"
+                                  public class Foo {
+                                  
+                                  ```
+
+                                  and some text after
+                                  """).strip(),
+                         result.strip())
+
+    def test_simple_case_selector_on_next_line(self):
+        plugin = CodeIncludePlugin()
+        result = plugin.on_page_markdown(MARKDOWN_EXAMPLE_SELECTOR_ON_NEXT_LINE, PAGE_EXAMPLE, dict())
+
+        print(result)
+        self.assertEqual(textwrap.dedent("""
+                                  # hello world
+
+                                  some text before
+
+                                  ```java tab=\"foo\"
+                                  public class Foo {
+                                  
+                                  ```
+
                                   and some text after
                                   """).strip(),
                          result.strip())


### PR DESCRIPTION
Allows targeting expressions to be on the next line:

```markdown
<!--codeinclude-->
<!-- On the same line -->
[Title](long/long/Path) targeting_expr1

<!-- On the next line -->
[Title2](long/long/Path)
targeting_expr2
<!--/codeinclude-->
```

I kept the usage of a regular expression to find the include definitions, but had to change the implementation to use `re.findall` and a multiline expression instead of `re.match` over a single line.

The processing is now separated into three stages:
1. Code-include block extraction.
2. Computing substitutes (patches) for each block.
3. Application of patches to the original markdown.

Resolves #9 