### PR TITLE
Proper multiple-tab code blocks

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,4 +1,3 @@
 XML blocks
-set lang based on extension
 highlight matching line
 

--- a/codeinclude/plugin.py
+++ b/codeinclude/plugin.py
@@ -155,9 +155,9 @@ class CodeIncludePlugin(BasePlugin):
         if self.config.get("title_mode") == "pymdownx.tabbed" and len(title) > 0:
             return f"""
 === "{title}"
-```{header}
-{dedented}
-```
+    ```{header}
+    {dedented}
+    ```
 
 """
         elif (

--- a/codeinclude/plugin.py
+++ b/codeinclude/plugin.py
@@ -1,4 +1,3 @@
-import enum
 import os
 import re
 import shlex
@@ -6,7 +5,7 @@ import textwrap
 from dataclasses import dataclass
 from typing import List
 
-import mkdocs
+import mkdocs.config.config_options
 from mkdocs.plugins import BasePlugin
 
 from codeinclude.languages import get_lang_class
@@ -153,10 +152,12 @@ class CodeIncludePlugin(BasePlugin):
         dedented = textwrap.dedent(selected_content)
 
         if self.config.get("title_mode") == "pymdownx.tabbed" and len(title) > 0:
+            # Newest version of pymdownx requires everything to be indented 4-spaces.
+            dedented = "".join([f'    {line}\n' for line in dedented.split('\n')])
             return f"""
 === "{title}"
     ```{header}
-    {dedented}
+{dedented}
     ```
 
 """

--- a/tests/codeinclude/test_languages.py
+++ b/tests/codeinclude/test_languages.py
@@ -4,14 +4,14 @@ from codeinclude.languages import get_lang_class
 
 class MyTestCase(unittest.TestCase):
     def test_get_lang_class(self):
-        self.assertEquals("java", get_lang_class("HelloWorld.java"))
-        self.assertEquals("python", get_lang_class("HelloWorld.py"))
-        self.assertEquals("csharp", get_lang_class("HelloWorld.cs"))
-        self.assertEquals("rust", get_lang_class("HelloWorld.rs"))
-        self.assertEquals("docker", get_lang_class("Dockerfile"))
-        self.assertEquals("xml", get_lang_class("HelloWorld.xml"))
-        self.assertEquals("toml", get_lang_class("HelloWorld.toml"))
-        self.assertEquals("json", get_lang_class("HelloWorld.json"))
+        self.assertEqual("java", get_lang_class("HelloWorld.java"))
+        self.assertEqual("python", get_lang_class("HelloWorld.py"))
+        self.assertEqual("csharp", get_lang_class("HelloWorld.cs"))
+        self.assertEqual("rust", get_lang_class("HelloWorld.rs"))
+        self.assertEqual("docker", get_lang_class("Dockerfile"))
+        self.assertEqual("xml", get_lang_class("HelloWorld.xml"))
+        self.assertEqual("toml", get_lang_class("HelloWorld.toml"))
+        self.assertEqual("json", get_lang_class("HelloWorld.json"))
 
 
 if __name__ == "__main__":

--- a/tests/codeinclude/test_plugin.py
+++ b/tests/codeinclude/test_plugin.py
@@ -2,7 +2,8 @@ import os
 import textwrap
 import unittest
 
-from mkdocs.config import Config, DEFAULT_SCHEMA
+import mkdocs.config.defaults
+from mkdocs.config import Config
 from mkdocs.structure.files import File
 from mkdocs.structure.pages import Page
 
@@ -99,7 +100,7 @@ and some text after
 
 """
 
-c = Config(schema=DEFAULT_SCHEMA)
+c = Config(schema=mkdocs.config.defaults.get_schema())
 c["site_url"] = "http://example.org/"
 
 PAGE_EXAMPLE = Page(


### PR DESCRIPTION
* Updates the TODO file list.
* on `pymdownx.tabbed`, we need the leading spaces on the tab content.
* Support for `pymdownx` v9.0