### PR TITLE
Add functionality to raise error if `block` or `include_block` is not found in file

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Note that:
 * Every line in the source file will be searched for an instance of the token (e.g. `doFoo`). If more than one line
   includes that token, then potentially more than one block could be targeted for inclusion. It is advisable to use a
   specific, unique token to avoid unexpected behaviour.
+* If the specified block is not found, behavior depends on the `block_throw` config value (see [Configuration](#configuration))
   
 When we wish to include a section of code that does not naturally appear within braces, we can simply insert our token,
 with matching braces, in a comment. 
@@ -126,6 +127,16 @@ will be rendered as:
 ```java
 doTheThingThatWeActuallyWantToShow();
 ```
+
+## Configuration
+
+This plugin takes two config values, specified in `mkdocs.yml`.
+
+| Name          | Description                                                                                                         | Values                                                   | Default           |
+|---------------|---------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------|-------------------|
+| `title_mode`  | Controls how titles are generated for included blocks                                                               | `none`, `legacy_pymdownx.superfences`, `pymdownx.tabbed` | `pymdownx.tabbed` |
+| `block_throw` | Controls whether to include entire file (`false`) or raise an error (`true`) if included block is not found in file | `true`, `false`                                          | `false`           |
+
 
 ## Building the Project
 

--- a/codeinclude/plugin.py
+++ b/codeinclude/plugin.py
@@ -62,6 +62,10 @@ class CodeIncludePlugin(BasePlugin):
                 default="pymdownx.tabbed",
             ),
         ),
+        (
+            "block_throw",
+            mkdocs.config.config_options.Type(bool, default=False)
+        )
     )
 
     def on_page_markdown(self, markdown, page, config, site_navigation=None, **kwargs):
@@ -147,7 +151,7 @@ class CodeIncludePlugin(BasePlugin):
             content = f.read()
 
         selected_content = select(
-            content, filename, lines=lines, block=block, inside_block=inside_block
+            content, filename=filename, lines=lines, block=block, inside_block=inside_block, block_throw=self.config["block_throw"]
         )
 
         dedented = textwrap.dedent(selected_content)

--- a/codeinclude/plugin.py
+++ b/codeinclude/plugin.py
@@ -147,7 +147,7 @@ class CodeIncludePlugin(BasePlugin):
             content = f.read()
 
         selected_content = select(
-            content, lines=lines, block=block, inside_block=inside_block
+            content, filename, lines=lines, block=block, inside_block=inside_block
         )
 
         dedented = textwrap.dedent(selected_content)

--- a/codeinclude/resolver.py
+++ b/codeinclude/resolver.py
@@ -45,7 +45,7 @@ def select(
             delim_count -= line.count("}")
 
         if not found_block:
-            raise ValueError("Block {block} not found to inject")
+            raise ValueError(f"Block {block} not found to inject")
 
     if inside_block:
         delim_count = 0
@@ -78,7 +78,7 @@ def select(
                 selected_lines.append(line_number)
         
         if not found_block:
-            raise ValueError("Block {block} not found to inject")
+            raise ValueError(f"Block {inside_block} not found to inject")
 
     if from_token and to_token:
         i = 0

--- a/codeinclude/resolver.py
+++ b/codeinclude/resolver.py
@@ -3,6 +3,7 @@ import re
 
 def select(
     text,
+    filename,
     lines=None,
     from_token=None,
     to_token=None,
@@ -45,7 +46,7 @@ def select(
             delim_count -= line.count("}")
 
         if not found_block:
-            raise ValueError(f"Block {block} not found to inject")
+            raise ValueError(f"Block {block} not found to inject from {filename}")
 
     if inside_block:
         delim_count = 0
@@ -78,7 +79,7 @@ def select(
                 selected_lines.append(line_number)
         
         if not found_block:
-            raise ValueError(f"Block {inside_block} not found to inject")
+            raise ValueError(f"Block {inside_block} not found to inject from {filename}")
 
     if from_token and to_token:
         i = 0

--- a/codeinclude/resolver.py
+++ b/codeinclude/resolver.py
@@ -27,10 +27,12 @@ def select(
     if block:
         i = 0
         delim_count = 0
+        found_block = False
         for line in text.splitlines():
             first_line_of_block = False
             i = i + 1
             if block in line and delim_count <= 0:
+                found_block = True
                 delim_count = 0
                 first_line_of_block = True
                 delim_count += line.count("{")
@@ -42,13 +44,19 @@ def select(
 
             delim_count -= line.count("}")
 
+        if not found_block:
+            raise ValueError("Block {block} not found to inject")
+
     if inside_block:
         delim_count = 0
         inside_matching = False
+        found_block = False
         for line_number, line in enumerate(text.splitlines(), start=1):
             first_line_of_block = False
+
             # Detect the block beginning
             if inside_block in line and delim_count <= 0:
+                found_block = True
                 delim_count = 0
                 first_line_of_block = True
                 inside_matching = True
@@ -68,6 +76,9 @@ def select(
             # Append the lines inside the matching block, skipping the first matching
             if inside_matching and not first_line_of_block:
                 selected_lines.append(line_number)
+        
+        if not found_block:
+            raise ValueError("Block {block} not found to inject")
 
     if from_token and to_token:
         i = 0

--- a/codeinclude/resolver.py
+++ b/codeinclude/resolver.py
@@ -3,13 +3,14 @@ import re
 
 def select(
     text,
-    filename,
+    filename=None,
     lines=None,
     from_token=None,
     to_token=None,
     block=None,
     inside_block=None,
     lang=None,
+    block_throw=False
 ):
 
     selected_lines = []
@@ -45,7 +46,7 @@ def select(
 
             delim_count -= line.count("}")
 
-        if not found_block:
+        if block_throw and not found_block:
             raise ValueError(f"Block {block} not found to inject from {filename}")
 
     if inside_block:
@@ -78,7 +79,7 @@ def select(
             if inside_matching and not first_line_of_block:
                 selected_lines.append(line_number)
         
-        if not found_block:
+        if block_throw and not found_block:
             raise ValueError(f"Block {inside_block} not found to inject from {filename}")
 
     if from_token and to_token:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,10 @@ def read_file(fname):
 
 setup(
     name='mkdocs-codeinclude-plugin',
-    version="1.0",
+    version_config={
+        "version_format": "{tag}.dev{sha}",
+        "starting_version": "0.2.0"
+    },
     description="A plugin to include code snippets into mkdocs pages",
     long_description=read_file('README.md'),
     long_description_content_type='text/markdown',
@@ -24,6 +27,7 @@ setup(
         'mkdocs>=1.2',
         'pygments>=2.9.0'
     ],
+    setup_requires=['better-setuptools-git-version'],
     classifiers=[
         'Intended Audience :: Developers',
         'Intended Audience :: Information Technology',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read_file(fname):
 
 setup(
     name='mkdocs-codeinclude-plugin',
-    version="1.0",
+    version="1.0.1",
     description="A plugin to include code snippets into mkdocs pages",
     long_description=read_file('README.md'),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,7 @@ def read_file(fname):
 
 setup(
     name='mkdocs-codeinclude-plugin',
-    version_config={
-        "version_format": "{tag}.dev{sha}",
-        "starting_version": "0.2.0"
-    },
+    version="1.0",
     description="A plugin to include code snippets into mkdocs pages",
     long_description=read_file('README.md'),
     long_description_content_type='text/markdown',
@@ -27,7 +24,6 @@ setup(
         'mkdocs>=1.2',
         'pygments>=2.9.0'
     ],
-    setup_requires=['better-setuptools-git-version'],
     classifiers=[
         'Intended Audience :: Developers',
         'Intended Audience :: Information Technology',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read_file(fname):
 
 setup(
     name='mkdocs-codeinclude-plugin',
-    version="1.0.1",
+    version="1.0",
     description="A plugin to include code snippets into mkdocs pages",
     long_description=read_file('README.md'),
     long_description_content_type='text/markdown',

--- a/tests/codeinclude/test_resolver.py
+++ b/tests/codeinclude/test_resolver.py
@@ -28,6 +28,24 @@ class ResolverTest(unittest.TestCase):
         result = select(CODE_BLOCK_EXAMPLE, block="blockstarter")
         self.assertEquals(("blockstarter {\n" "    block content\n" "}\n"), result)
 
+    def test_block_throw(self):
+        # Test that entire file is returned for nonexistent block where `block_throw`=False
+        result = select(CODE_BLOCK_EXAMPLE, "test_file", block="nonexistent_block", block_throw=False)
+        self.assertEquals(CODE_BLOCK_EXAMPLE, result)
+
+        # ...as well as for inside_block
+        result = select(CODE_BLOCK_EXAMPLE, "test_file", inside_block="nonexistent_block", block_throw=False)
+        self.assertEquals(CODE_BLOCK_EXAMPLE, result)
+
+        # Test that throw occurs for nonexistent block
+        with self.assertRaises(ValueError):
+          result = select(CODE_BLOCK_EXAMPLE, "test_file", block="nonexistent_block", block_throw=True)
+
+        # ...as well as for inside_block
+        with self.assertRaises(ValueError):
+          result = select(CODE_BLOCK_EXAMPLE, "test_file", inside_block="nonexistent_block", block_throw=True)
+
+
     def test_block_curly_on_same_line(self):
         result = select(
             textwrap.dedent(


### PR DESCRIPTION
The current behavior for `block` and `include_block` is to return the full contents of the file if the block is not found. This is not optimal for our use case -- a block not being found is, to us, an error which should prevent the building of our docs site entirely.


This PR:

- Adds a config option, `block_throw`, which defaults to `false`.
  - If `false`, behavior remains unchanged.
  - If `true`, the `select()` method will raise a `ValueError` if `block` or `inside_block` are not `None`, and the requested block is not found in the file.
- Updates `README.md`
  - Explains behavior if block not found
  - Adds `Configuration` section detailing config options
- Adds tests for new behavior